### PR TITLE
Fallback using enum

### DIFF
--- a/src/main/java/com/tweesky/cloudtools/codegen/TestContainersCodegen.java
+++ b/src/main/java/com/tweesky/cloudtools/codegen/TestContainersCodegen.java
@@ -21,9 +21,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.tweesky.cloudtools.codegen.samples.*;
 import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.media.*;
-import org.joda.time.DateTime;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.languages.AbstractGoCodegen;
 import org.openapitools.codegen.meta.GeneratorMetadata;
@@ -661,36 +661,24 @@ public class TestContainersCodegen extends AbstractGoCodegen {
             String key = mapElement.getKey();
             Object value = mapElement.getValue();
 
-            if (value instanceof String) {
+            if (value instanceof StringSchema) {
                 ret = ret + JSON_ESCAPE_DOUBLE_QUOTE + key + JSON_ESCAPE_DOUBLE_QUOTE + ": " +
-                        JSON_ESCAPE_DOUBLE_QUOTE + value + JSON_ESCAPE_DOUBLE_QUOTE;
-            } else if (value instanceof StringSchema) {
-                ret = ret + JSON_ESCAPE_DOUBLE_QUOTE + key + JSON_ESCAPE_DOUBLE_QUOTE + ": " +
-                        JSON_ESCAPE_DOUBLE_QUOTE + getSampleValue(key) + JSON_ESCAPE_DOUBLE_QUOTE;
-            } else if (value instanceof Integer) {
-                ret = ret + JSON_ESCAPE_DOUBLE_QUOTE + key + JSON_ESCAPE_DOUBLE_QUOTE + ": " +
-                        value;
+                        JSON_ESCAPE_DOUBLE_QUOTE + new StringSample(value).getValue(key) + JSON_ESCAPE_DOUBLE_QUOTE;
             } else if (value instanceof IntegerSchema) {
                 ret = ret + JSON_ESCAPE_DOUBLE_QUOTE + key + JSON_ESCAPE_DOUBLE_QUOTE + ": " +
-                        "0";
+                        new IntegerSample(value).getValue(key);
             } else if (value instanceof EmailSchema) {
                 ret = ret + JSON_ESCAPE_DOUBLE_QUOTE + key + JSON_ESCAPE_DOUBLE_QUOTE + ": " +
-                        JSON_ESCAPE_DOUBLE_QUOTE + "user@example.com" + JSON_ESCAPE_DOUBLE_QUOTE;
-            } else if (value instanceof Date) {
-                ret = ret + JSON_ESCAPE_DOUBLE_QUOTE + key + JSON_ESCAPE_DOUBLE_QUOTE + ": " +
-                        JSON_ESCAPE_DOUBLE_QUOTE + "01/01/2000" + JSON_ESCAPE_DOUBLE_QUOTE;
+                        JSON_ESCAPE_DOUBLE_QUOTE + new EmailSample(value).getValue(key) + JSON_ESCAPE_DOUBLE_QUOTE;
             } else if (value instanceof DateSchema) {
                 ret = ret + JSON_ESCAPE_DOUBLE_QUOTE + key + JSON_ESCAPE_DOUBLE_QUOTE + ": " +
-                        JSON_ESCAPE_DOUBLE_QUOTE + "01/01/2000" + JSON_ESCAPE_DOUBLE_QUOTE;
-            } else if (value instanceof DateTime) {
-                ret = ret + JSON_ESCAPE_DOUBLE_QUOTE + key + JSON_ESCAPE_DOUBLE_QUOTE + ": " +
-                        JSON_ESCAPE_DOUBLE_QUOTE + "01/01/2000 h00:00:00" + JSON_ESCAPE_DOUBLE_QUOTE;
+                        JSON_ESCAPE_DOUBLE_QUOTE + new DateSample(value).getValue(key) + JSON_ESCAPE_DOUBLE_QUOTE;
             } else if (value instanceof DateTimeSchema) {
                 ret = ret + JSON_ESCAPE_DOUBLE_QUOTE + key + JSON_ESCAPE_DOUBLE_QUOTE + ": " +
-                        JSON_ESCAPE_DOUBLE_QUOTE + "01/01/2000 h00:00:00" + JSON_ESCAPE_DOUBLE_QUOTE;
+                        JSON_ESCAPE_DOUBLE_QUOTE + new DateTimeSample(value).getValue(key) + JSON_ESCAPE_DOUBLE_QUOTE;
             } else if (value instanceof BooleanSchema) {
                 ret = ret + JSON_ESCAPE_DOUBLE_QUOTE + key + JSON_ESCAPE_DOUBLE_QUOTE + ": " +
-                        "true";
+                        new BooleanSample(value).getValue(key);
             } else if (value instanceof ArraySchema) {
                 ret = ret + JSON_ESCAPE_DOUBLE_QUOTE + key + JSON_ESCAPE_DOUBLE_QUOTE + ": " +
                         "[]";
@@ -726,54 +714,6 @@ public class TestContainersCodegen extends AbstractGoCodegen {
         ret = ret + JSON_ESCAPE_NEW_LINE + "}";
 
         return ret;
-    }
-
-    /**
-     * Get a 'reasonable' sample value for the given field
-     * @param key
-     * @return
-     */
-    String getSampleValue(String key) {
-        String value = "";
-
-        if(key.equalsIgnoreCase("currency")) {
-            value = "EUR";
-        } else if(key.equalsIgnoreCase("country")) {
-            value = "NL";
-        } else if(key.equalsIgnoreCase("countryCode")) {
-            value = "NL";
-        } else if(key.equalsIgnoreCase("postalCode")) {
-            value = "11AA";
-        } else if(key.equalsIgnoreCase("city")) {
-            value = "Amsterdam";
-        } else if(key.equalsIgnoreCase("street")) {
-            value = "Park Av.";
-        } else if(key.equalsIgnoreCase("nationality")) {
-            value = "NL";
-        } else if(key.equalsIgnoreCase("url")) {
-            value = "https://www.example.com";
-        } else if(key.equalsIgnoreCase("email")) {
-            value = "user@example.com";
-        } else if(key.endsWith("email") || key.endsWith("Email")) {
-            value = "user@example.com";
-        } else if(key.equalsIgnoreCase("firstname")) {
-            value = "Alice";
-        } else if(key.equalsIgnoreCase("lastname")) {
-            value = "Cooper";
-        } else if(key.equalsIgnoreCase("iban")) {
-            value = "NL13TEST0123456789";
-        } else if(key.equalsIgnoreCase("telephonenumber")) {
-            value = "09 1234567890";
-        } else if(key.equalsIgnoreCase("os")) {
-            value = "n/a";
-        } else if(key.equalsIgnoreCase("locale")) {
-            value = "en";
-        } else if(key.endsWith("version") || key.endsWith("Version")) {
-            value = "1.0";
-        } else if(key.endsWith("reference") || key.endsWith("Reference")) {
-            value = "ref001";
-        }
-        return value;
     }
 
     public String getInputSpecFilename(String inputSpec) {

--- a/src/main/java/com/tweesky/cloudtools/codegen/samples/BooleanSample.java
+++ b/src/main/java/com/tweesky/cloudtools/codegen/samples/BooleanSample.java
@@ -1,0 +1,15 @@
+package com.tweesky.cloudtools.codegen.samples;
+
+public class BooleanSample implements SampleValue {
+
+    private Object schema;
+
+    public BooleanSample(Object schema) {
+        this.schema = schema;
+    }
+
+    @Override
+    public String getValue(String key) {
+        return "true";
+    }
+}

--- a/src/main/java/com/tweesky/cloudtools/codegen/samples/DateSample.java
+++ b/src/main/java/com/tweesky/cloudtools/codegen/samples/DateSample.java
@@ -1,0 +1,15 @@
+package com.tweesky.cloudtools.codegen.samples;
+
+public class DateSample implements SampleValue {
+
+    private Object schema;
+
+    public DateSample(Object schema) {
+        this.schema = schema;
+    }
+
+    @Override
+    public String getValue(String key) {
+        return "01/01/2000";
+    }
+}

--- a/src/main/java/com/tweesky/cloudtools/codegen/samples/DateTimeSample.java
+++ b/src/main/java/com/tweesky/cloudtools/codegen/samples/DateTimeSample.java
@@ -1,0 +1,15 @@
+package com.tweesky.cloudtools.codegen.samples;
+
+public class DateTimeSample implements SampleValue {
+
+    private Object schema;
+
+    public DateTimeSample(Object schema) {
+        this.schema = schema;
+    }
+
+    @Override
+    public String getValue(String key) {
+        return "01/01/2000 h00:00:00";
+    }
+}

--- a/src/main/java/com/tweesky/cloudtools/codegen/samples/EmailSample.java
+++ b/src/main/java/com/tweesky/cloudtools/codegen/samples/EmailSample.java
@@ -1,0 +1,15 @@
+package com.tweesky.cloudtools.codegen.samples;
+
+public class EmailSample implements SampleValue {
+
+    private Object schema;
+
+    public EmailSample(Object schema) {
+        this.schema = schema;
+    }
+
+    @Override
+    public String getValue(String key) {
+        return "user@example.com";
+    }
+}

--- a/src/main/java/com/tweesky/cloudtools/codegen/samples/IntegerSample.java
+++ b/src/main/java/com/tweesky/cloudtools/codegen/samples/IntegerSample.java
@@ -1,0 +1,15 @@
+package com.tweesky.cloudtools.codegen.samples;
+
+public class IntegerSample implements SampleValue {
+
+    private Object schema;
+
+    public IntegerSample(Object schema) {
+        this.schema = schema;
+    }
+
+    @Override
+    public String getValue(String key) {
+        return "0";
+    }
+}

--- a/src/main/java/com/tweesky/cloudtools/codegen/samples/SampleValue.java
+++ b/src/main/java/com/tweesky/cloudtools/codegen/samples/SampleValue.java
@@ -1,0 +1,8 @@
+package com.tweesky.cloudtools.codegen.samples;
+
+import io.swagger.v3.oas.models.media.StringSchema;
+
+public interface SampleValue {
+
+    String getValue(String key);
+}

--- a/src/main/java/com/tweesky/cloudtools/codegen/samples/StringSample.java
+++ b/src/main/java/com/tweesky/cloudtools/codegen/samples/StringSample.java
@@ -1,0 +1,63 @@
+package com.tweesky.cloudtools.codegen.samples;
+
+import io.swagger.v3.oas.models.media.StringSchema;
+
+public class StringSample implements SampleValue {
+
+    private StringSchema schema;
+
+    public StringSample(Object schema) {
+        this.schema = (StringSchema) schema;
+    }
+
+    @Override
+    public String getValue(String key) {
+
+        String value = "";
+
+        // check enum
+        if (schema.getEnum() != null && !schema.getEnum().isEmpty()) {
+            return schema.getEnum().get(0);
+        }
+
+        // generate a 'reasonable' value for the given field
+        if (key.equalsIgnoreCase("currency")) {
+            value = "EUR";
+        } else if (key.equalsIgnoreCase("country")) {
+            value = "NL";
+        } else if (key.equalsIgnoreCase("countryCode")) {
+            value = "NL";
+        } else if (key.equalsIgnoreCase("postalCode")) {
+            value = "11AA";
+        } else if (key.equalsIgnoreCase("city")) {
+            value = "Amsterdam";
+        } else if (key.equalsIgnoreCase("street")) {
+            value = "Park Av.";
+        } else if (key.equalsIgnoreCase("nationality")) {
+            value = "NL";
+        } else if (key.equalsIgnoreCase("url")) {
+            value = "https://www.example.com";
+        } else if (key.equalsIgnoreCase("email")) {
+            value = "user@example.com";
+        } else if (key.endsWith("email") || key.endsWith("Email")) {
+            value = "user@example.com";
+        } else if (key.equalsIgnoreCase("firstname")) {
+            value = "Alice";
+        } else if (key.equalsIgnoreCase("lastname")) {
+            value = "Cooper";
+        } else if (key.equalsIgnoreCase("iban")) {
+            value = "NL13TEST0123456789";
+        } else if (key.equalsIgnoreCase("telephonenumber")) {
+            value = "09 1234567890";
+        } else if (key.equalsIgnoreCase("os")) {
+            value = "n/a";
+        } else if (key.equalsIgnoreCase("locale")) {
+            value = "en";
+        } else if (key.endsWith("version") || key.endsWith("Version")) {
+            value = "1.0";
+        } else if (key.endsWith("reference") || key.endsWith("Reference")) {
+            value = "ref001";
+        }
+        return value;
+    }
+}

--- a/src/test/java/com/tweesky/cloudtools/codegen/TestContainersCodegenTest.java
+++ b/src/test/java/com/tweesky/cloudtools/codegen/TestContainersCodegenTest.java
@@ -21,7 +21,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 public class TestContainersCodegenTest {
 
@@ -147,6 +146,32 @@ public class TestContainersCodegenTest {
         // check generated email address
         TestUtils.assertFileContains(Paths.get(output + "/api/api_basic.go"),
                 "\"user@example.com\"");
+
+    }
+
+    @Test
+    public void generateFromSchemaWithEnum() throws IOException {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("test-containers")
+                .setInputSpec("src/test/resources/test-containers/specWithEnum.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        TestUtils.assertFileContains(Paths.get(output + "/main.go"),
+                "package main");
+
+        log(output + "/api/api_basic.go");
+
+        TestUtils.assertFileExists(Paths.get(output + "/api/api_basic.go"));
+        // check country value from enum
+        TestUtils.assertFileContains(Paths.get(output + "/api/api_basic.go"),
+                "\"country\" : \"UK\"");
 
     }
 
@@ -291,7 +316,6 @@ public class TestContainersCodegenTest {
         String EXPECTED = "myopenapi.yaml";
         assertEquals(EXPECTED, new TestContainersCodegen().getInputSpecFilename(INPUT_SPEC));
     }
-
 
     private void log(String filename) throws IOException {
         System.out.println(new String(Files.readAllBytes(Paths.get(filename)), StandardCharsets.UTF_8));

--- a/src/test/java/com/tweesky/cloudtools/codegen/samples/DateSampleTest.java
+++ b/src/test/java/com/tweesky/cloudtools/codegen/samples/DateSampleTest.java
@@ -1,0 +1,18 @@
+package com.tweesky.cloudtools.codegen.samples;
+
+import io.swagger.v3.oas.models.media.DateSchema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import org.testng.annotations.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DateSampleTest {
+
+    @Test
+    public void getValue() {
+        String key = "created";
+        DateSchema value = new DateSchema().type("date");
+        assertEquals("01/01/2000", new DateSample(value).getValue(key));
+    }
+
+}

--- a/src/test/java/com/tweesky/cloudtools/codegen/samples/StringSampleTest.java
+++ b/src/test/java/com/tweesky/cloudtools/codegen/samples/StringSampleTest.java
@@ -1,0 +1,26 @@
+package com.tweesky.cloudtools.codegen.samples;
+
+import io.swagger.v3.oas.models.media.StringSchema;
+import org.testng.annotations.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class StringSampleTest {
+
+    // generate value for given key
+    @Test
+    public void getValue() {
+        String key = "country";
+        StringSchema value = new StringSchema().type("string");
+        assertEquals("NL", new StringSample(value).getValue(key));
+    }
+
+    // get first enum as value
+    @Test
+    public void getValueFromEnum() {
+        String key = "country";
+        StringSchema value = new StringSchema().type("string").addEnumItem("UK").addEnumItem("NL");
+        assertEquals("UK", new StringSample(value).getValue(key));
+    }
+
+}

--- a/src/test/resources/test-containers/specWithEnum.yaml
+++ b/src/test/resources/test-containers/specWithEnum.yaml
@@ -1,0 +1,104 @@
+openapi: 3.0.0
+info:
+  title: API spec
+  version: '1.0'
+paths:
+  '/users/{userId}':
+    get:
+      summary: Get User Info by Query Param
+      operationId: get-users-userId
+      description: Retrieve the information of the user with the matching user ID.
+      tags:
+        - basic
+      parameters:
+        - description: User identifier
+          name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+#            example: 888
+#          examples:
+#            valid:
+#              value: 1
+#              summary: success 200
+#            not found:
+#              value: 2
+#              summary: error 404
+
+      responses:
+        '200':
+          description: User Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '404':
+          description: User Not Found
+
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      name: X-API-Key
+      in: header
+  schemas:
+    User:
+      title: User
+      type: object
+      description: ''
+      example:
+        id: 999
+        firstName: Alice9 schema example
+        lastName: Smith9
+        email: alice.smith@gmail.com
+        dateOfBirth: '1997-10-31'
+        emailVerified: true
+        createDate: '2019-08-24'
+      properties:
+        id:
+          type: integer
+          description: Unique identifier for the given user.
+          example: 0
+        firstName:
+          type: string
+          example: Alix
+        lastName:
+          type: string
+          example: Smith
+        country:
+          type: string
+          enum:
+            - UK
+            - NL
+            - US
+            - IT
+            - FR
+            - ES
+      required:
+        - id
+        - firstName
+        - lastName
+    Error:
+      title: Error object
+      type: object
+      description: 'An error'
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+        - code
+        - message
+    Country:
+      type: string
+      enum:
+        - NL
+        - US
+        - IT
+        - FR
+        - ES
+tags:
+  - name: basic
+    description: Basic tag


### PR DESCRIPTION
When generating the fallback response use `enum` when available, otherwise generate a 'reasonable' sample value

Fixes #21 